### PR TITLE
Remove italic style from emphasis

### DIFF
--- a/_site/css/main.css
+++ b/_site/css/main.css
@@ -56,7 +56,6 @@ h3 {
 }
 
 em {
-  font-style: italic;
   background-color: rgb(120, 145, 24);
   color: white;
   border: 1px solid rgb(60, 74, 1);

--- a/css/main.scss
+++ b/css/main.scss
@@ -69,7 +69,6 @@ h3 {
 }
 
 em {
-  font-style: italic;
   background-color: rgb(120, 145, 24);
   color: white;
   border: 1px solid rgb(60, 74, 1);


### PR DESCRIPTION
## Summary
- remove the initial italic style from the `em` rule in `main.scss`
- update the generated CSS in `_site` accordingly

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e388d65fc833198e0877a13c67121