### PR TITLE
Fix navigation links for subdirectory builds

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,7 +21,7 @@
             <ul>
               {% for item in site.data.navigation %}
               {% capture new_url %}{{item.url}}.html{% endcapture %}
-              <li  {% if page.url == new_url %} class="active"{% endif %}><a href="{{ item.url }}">{{ item.title }}</a></li>
+              <li  {% if page.url == new_url %} class="active"{% endif %}><a href="{{ item.url | relative_url }}">{{ item.title }}</a></li>
               {% endfor %}
             </ul>
           </div>

--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -21,7 +21,7 @@
             <ul>
               {% for item in site.data.navigation %}
               {% capture new_url %}{{item.url}}.html{% endcapture %}
-              <li  {% if page.url == new_url %} class="active"{% endif %}><a href="{{ item.url }}">{{ item.title }}</a></li>
+              <li  {% if page.url == new_url %} class="active"{% endif %}><a href="{{ item.url | relative_url }}">{{ item.title }}</a></li>
               {% endfor %}
             </ul>
           </div>


### PR DESCRIPTION
## Summary
- ensure nav links use Jekyll's `relative_url` filter in both layouts

## Testing
- `bundle exec jekyll build` *(fails: bundler cannot install due to network restrictions)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e38a50a348331b597aef20e84eb88