### PR TITLE
Fix emphasis styling

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -75,7 +75,6 @@ em {
   border: 1px solid rgb(60, 74, 1);
   border-radius: 8px;
   padding: 0.2em 0.4em;
-  font-style: normal;
   line-height: 2em;
 }
 


### PR DESCRIPTION
## Summary
- ensure emphasized text stays italic by removing CSS override

## Testing
- `bundle exec jekyll build` *(fails: bundler command not found)*
- `bundle install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685e3794151483319869159de721549a